### PR TITLE
Update svr-chansession for build issue

### DIFF
--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -1040,9 +1040,11 @@ static void execchild(const void *user_data) {
 	if (chansess->original_command) {
 		addnewvar("SSH_ORIGINAL_COMMAND", chansess->original_command);
 	}
+#if DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT
         if (ses.authstate.pubkey_info != NULL) {
-                addnewvar("SSH_PUBKEYINFO", ses.authstate.pubkey_info);
+            addnewvar("SSH_PUBKEYINFO", ses.authstate.pubkey_info);
         }
+#endif
 
 	/* change directory */
 	if (chdir(ses.authstate.pw_dir) < 0) {

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -1041,9 +1041,9 @@ static void execchild(const void *user_data) {
 		addnewvar("SSH_ORIGINAL_COMMAND", chansess->original_command);
 	}
 #if DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT
-        if (ses.authstate.pubkey_info != NULL) {
-            addnewvar("SSH_PUBKEYINFO", ses.authstate.pubkey_info);
-        }
+	if (ses.authstate.pubkey_info != NULL) {
+		addnewvar("SSH_PUBKEYINFO", ses.authstate.pubkey_info);
+	}
 #endif
 
 	/* change directory */


### PR DESCRIPTION
Following issue "Compilation error when disabling pubkey authentication (DROPBEAR_SVR_PUBKEY_AUTH)" from davidbernard04, code is modified to take in account that requesting information from method "ses.authstate.pubkey_info" isn't possible since the method is disabled when DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT value is 0.
Fixes mkj/dropbear#168